### PR TITLE
changed number of available glTF mesh primitive test models to 3

### DIFF
--- a/Demos/GLTFTests/generatedAssets.json
+++ b/Demos/GLTFTests/generatedAssets.json
@@ -31,7 +31,7 @@
             "url": "?test=Mesh_PrimitiveMode&count=16&width=6&position=[-2.8,1.3,0.0]&radius=5.6&%20Alpha&flip=false&showMenu=true"
         },
         "Mesh_Primitives": {
-            "url": "?test=Mesh_Primitives&count=6&width=4&position=[-1.8,0.7,0.0]&radius=4&flip=false&showMenu=true"
+            "url": "?test=Mesh_Primitives&count=3&width=4&position=[-1.8,0.7,0.0]&radius=4&flip=false&showMenu=true"
         },
         "Mesh_PrimitivesUV": {
             "url": "?test=Mesh_PrimitivesUV&count=9&width=5&position=[-2.4,1.3,0.0]&radius=5.4&flip=false&showMenu=true"

--- a/Demos/GLTFTests/index.js
+++ b/Demos/GLTFTests/index.js
@@ -175,7 +175,7 @@ function createMeshPrimitiveModeScene(engine) {
 function createMeshPrimitivesScene(engine) {
     var glTFParameters = {};
     glTFParameters["test"] = "Mesh_Primitives";
-    glTFParameters["count"] = 6;
+    glTFParameters["count"] = 3;
     glTFParameters["width"] = 4;
     glTFParameters["position"] = [-1.8, 0.7, 0.0];
     glTFParameters["radius"] = 4;


### PR DESCRIPTION
The number of glTF mesh primitive models have been reduced to 3, though the test was still looking for 6 models and threw errors when it couldn't find the other models.  This update fixes that.