### PR TITLE
playground demo support on the website

### DIFF
--- a/src/assets/js/scripts.js
+++ b/src/assets/js/scripts.js
@@ -1,9 +1,9 @@
-window.onload = function() {
+window.onload = function () {
     //    Carousel
     var carouselContainer = document.querySelector('.carousel');
     if (carouselContainer) {
         var carouselPaginationItems = document.querySelectorAll('.carousel-navigate-item');
-        var windowWidth = document.documentElement.clientWidth;
+        var carouselItems = carouselContainer.querySelectorAll('.img-holder');
         var caretStep = 55;
         var caret = document.querySelector('.carousel-navigate .caret');
         var currentSlide = 0;
@@ -22,7 +22,7 @@ window.onload = function() {
                             // WebGL is enabled.
                             return 1;
                         }
-                    } catch (e) { }
+                    } catch (e) {}
                 }
 
                 // WebGL is supported, but disabled.
@@ -40,7 +40,7 @@ window.onload = function() {
             carouselContainer.appendChild(frame);
             var overlay = document.createElement("div");
             overlay.setAttribute("class", 'iframe-overlay');
-            overlay.addEventListener('click', function(e) {
+            overlay.addEventListener('click', function (e) {
                 e.target.classList.add('hidden');
             });
             carouselContainer.appendChild(overlay);
@@ -69,15 +69,67 @@ window.onload = function() {
 
             var interval = setInterval(setAutoSlide, delay);
 
-            carouselPaginationItems.forEach(function(item) {
-                item.addEventListener('click', function() {
+            carouselPaginationItems.forEach(function (item) {
+
+                item.addEventListener('click', function () {
                     initiateScroll(item.dataset.order);
 
-                    clearInterval(interval);
+                    if (interval) {
+                        clearInterval(interval);
+                        interval = undefined;
+                    }
                     interval = setInterval(setAutoSlide, delay);
                 });
             });
-            window.addEventListener('resize', function() {
+
+            carouselItems.forEach(function (item) {
+                // add event listeners to stop the slider if on top of them
+                // supporting mouse events as well for older browsers.
+                ['click', 'mousemove', 'pointermove'].forEach(function (eventType) {
+                    item.addEventListener(eventType, function () {
+                        if (interval) {
+                            clearInterval(interval);
+                            interval = undefined;
+                        }
+                    });
+                });
+
+                ['pointerout', 'mouseout'].forEach(function (eventType) {
+                    item.addEventListener(eventType, function () {
+                        if (interval) {
+                            clearInterval(interval);
+                        }
+                        interval = setInterval(setAutoSlide, delay);
+                    });
+                });
+            });
+
+            // mobile scroll-stop support
+
+            // when entering the iframe:
+            var inIframe = false;
+            window.addEventListener('blur', function () {
+                inIframe = true;
+                if (interval) {
+                    clearInterval(interval);
+                    interval = undefined;
+                }
+            });
+
+            // when clicking anywhere outside of the iframe
+            window.addEventListener('pointerdown', function() {
+                if(inIframe) {
+                    inIframe = false;
+                    // just to be sure
+                    if (interval) {
+                        clearInterval(interval);
+                        interval = undefined;
+                    }
+                    interval = setInterval(setAutoSlide, delay);
+                }
+            })
+
+            window.addEventListener('resize', function () {
                 windowWidth = document.documentElement.clientWidth;
                 initiateScroll(currentSlide);
                 clearInterval(interval);
@@ -107,7 +159,7 @@ window.onload = function() {
     }
 
     // Check is menu open and click was outside menu and close it.
-    window.addEventListener('click', function(e) {
+    window.addEventListener('click', function (e) {
         var isMenuActive = headerTopWrapper.classList.contains('show');
         if (e.target.closest('.menu') === null && e.target.closest('.menu-btn') === null && isMenuActive) {
             showMenu();
@@ -121,7 +173,7 @@ window.onload = function() {
             headerTopWrapper.classList.remove('overflow');
         } else {
             menuBtn.classList.remove("active");
-            setTimeout(function() {
+            setTimeout(function () {
                 headerTopWrapper.classList.add('overflow');
             }, 500);
         }
@@ -134,7 +186,7 @@ window.onload = function() {
             var item = document.querySelector('.sub-menu .' + activeElement.firstChild.classList[0]);
 
             item.parentNode.classList.add('no-transition');
-            setTimeout(function() {
+            setTimeout(function () {
                 item.classList.add('hidden');
                 item.parentNode.classList.remove('no-transition');
             }, 100);
@@ -156,7 +208,7 @@ window.onload = function() {
             clickedMenuItem = clickedMenuItem.parentNode;
         }
 
-        document.querySelectorAll('.sub-menu ul').forEach(function(item) {
+        document.querySelectorAll('.sub-menu ul').forEach(function (item) {
             item.classList.add('hidden');
         });
 

--- a/src/assets/styles/carousel.css
+++ b/src/assets/styles/carousel.css
@@ -43,7 +43,7 @@
 
 .carousel-navigate {
     position: absolute;
-    bottom: 30px;
+    bottom: 8px;
     left: 50%;
     transform: translateX(-50%);
     background: var(--background);

--- a/src/content/config.json
+++ b/src/content/config.json
@@ -51,18 +51,20 @@
         },
         {
             "templateName": "carouselBlock",
-            "delay": 2000,
             "content": {
+                "delay": 5000,
                 "items": [
                     {
-                        "videoUrl": "/assets/videos/clearCoatWeb.mp4"
+                        "playgroundCode": "#LR4YHT#6",
+                        "description": "Fire Material"
                     },
                     {
-                        "videoUrl": "/assets/videos/marbleTowerWeb.mp4",
-                        "demoLink": "https://playground.babylonjs.com/#3I55DK#0"
+                        "playgroundCode": "#3I55DK#0",
+                        "description": "Marble Tower"
                     },
                     {
-                        "videoUrl": "/assets/videos/mBlurFanWeb.mp4"
+                        "playgroundCode": "#LL5BIQ#0",
+                        "description": "Animations"
                     }
                 ]
             }
@@ -88,7 +90,7 @@
                         "link": "https://playground.babylonjs.com/#3I55DK#0",
                         "img": {
                             "url": "../community/assets/img/marbletower.jpg",
-                            "alt": "Local War"
+                            "alt": "Marble Tower"
                         }
                     },
                     {

--- a/src/templates/carouselBlock-template.html
+++ b/src/templates/carouselBlock-template.html
@@ -1,8 +1,8 @@
 <div class="samples-carousel-block">
-    <div class="carousel" data-sample="{{delay}}">
+    <div class="carousel" data-delay="{{delay}}">
         {{#each items}}
-        {{#if videoUrl}}
         <div class="img-holder">
+            {{#if videoUrl}}
             {{#if demoLink}}
             <a href="{{demoLink}}" target="_blank">
                 <video src='{{videoUrl}}' autoplay loop muted></video>
@@ -10,20 +10,22 @@
             {{else}}
             <video src='{{videoUrl}}' autoplay loop muted></video>
             {{/if}}
-        </div>
-        {{/if}}
-        {{#if imgUrl}}
-        <div class="img-holder">
+            
+            {{/if}}
+            {{#if imgUrl}}
             <img class="img-carousel" src='{{imgUrl}}'></video>
+            {{/if}}
+            {{#if playgroundCode}}
+            <iframe src="https://playground.babylonjs.com/frame.html{{playgroundCode}}"></iframe>
+            {{/if}}
         </div>
-        {{/if}}
         {{/each}}
     </div>
     <div class="carousel-navigate">
         <img src="/assets/img/CarouselActive.svg" alt="" class="caret">
         {{#each items}}
         <div class="carousel-navigate-item" data-order="{{@index}}">
-            <img src="/assets/img/CarouselBreadcrumb.svg" alt="">
+            <img src="/assets/img/CarouselBreadcrumb.svg" alt="{{description}}" title="{{description}}">
         </div>
         {{/each}}
     </div>

--- a/src/templates/downTriangle-template.html
+++ b/src/templates/downTriangle-template.html
@@ -1,4 +1,4 @@
-<div class="downTriangle-block" style="margin-bottom:{{marginBottom}}">
+<div class="downTriangle-block">
     <div class="downTriangle-background">
         <a href="{{link}}">
             <div class="hex-container">


### PR DESCRIPTION
The website carousel now supports playground demos.

Changes:

* set `playgroundCode` in config to have a new playground demo
* when in (or hovering above) the playground, carousel will not auto-change until out of the demo
* Added "title" to carousel links so mouse hover will show what's there
* Mobile friendly (with a few hacks to support iframe focus and blur)
* Set 3 (random!) playground links

Please **change the demo codes before deploying** :-)

Note that to make the demo "zoomable", the demo needs to have `noPreventDefault` set to false when using `camera.attachControl`. Otherwise the user will simply scroll through the demo when trying to zoom.