### PR TITLE
Add new community links

### DIFF
--- a/src/content/site.json
+++ b/src/content/site.json
@@ -49,6 +49,31 @@
                     "target": "_blank"
                 },
                 {
+                    "menuTitle": "TWITTER",
+                    "menuUrl": "https://twitter.com/hashtag/babylonjs",
+                    "target": "_blank"
+                },
+                {
+                    "menuTitle": "FACEBOOK",
+                    "menuUrl": "https://facebook.com/hashtag/babylonjs",
+                    "target": "_blank"
+                },
+                {
+                    "menuTitle": "INSTAGRAM",
+                    "menuUrl": "https://instagram.com/explore/tags/babylonjs",
+                    "target": "_blank"
+                },
+                {
+                    "menuTitle": "TIKTOK",
+                    "menuUrl": "https://tiktok.com/amp/tag/babylonjs",
+                    "target": "_blank"
+                },
+                {
+                    "menuTitle": "DISCORD",
+                    "menuUrl": "https://discord.gg/bn2xx6VkbP",
+                    "target": "_blank"
+                },
+                {
                     "menuTitle": "DEMOS",
                     "menuUrl": "/community"
                 }


### PR DESCRIPTION
Four new proposed hashtag links and one new community group invite.

![image](https://user-images.githubusercontent.com/69180012/167219423-8541240c-508e-485c-bf26-2224e463aaca.png)

* The unofficial Babylon.js [Reddit] subreddit was not included because the subreddit it's mostly likely to be banned due to inactive owner/moderators
Feel free to request ownership of it if someone has the minimum karma requirement.
* I didn't include a link for global Github search for "BabylonJS" or "Babylon.js" either, although I could, if anyone would like me to wanted.
* The Discord invite was made by me and shows as much if the invite is attempted to used.
It would look much more official if @deltakosh (who's on the Discord), created an invite himself with these invite settings.
![image](https://user-images.githubusercontent.com/69180012/167219805-411360b6-9889-4681-9956-d2b665a6d4d5.png)
* Personally, I would raise the Discord link priority higher then the other links, but still lower then the forum, mainly because it's more than just a place to get help, but also a place to showcase projects and games and collaborate with other people. But that's probably just my opinion.