### PR TITLE
Fix broken links for libraries in Specifications

### DIFF
--- a/src/content/specifications/config.json
+++ b/src/content/specifications/config.json
@@ -322,13 +322,13 @@
                                 ],
                                 [
                                     {
-                                        "link": "https://github.com/BabylonJS/Babylon.js/tree/master/proceduralTexturesLibrary",
+                                        "link": "https://doc.babylonjs.com/divingDeeper/materials/using/proceduralTextures",
                                         "text": "Procedural textures library"
                                     }
                                 ],
                                 [
                                     {
-                                        "link": "https://github.com/BabylonJS/Babylon.js/tree/master/materialsLibrary",
+                                        "link": "https://doc.babylonjs.com/toolsAndResources/assetLibraries/materialsLibrary",
                                         "text": "Materials library"
                                     }
                                 ]


### PR DESCRIPTION
Fixes: https://github.com/BabylonJS/Babylon.js/issues/12514

Links were broken due to the new build system. I replaced them with links to the documentation, since that's more immediately helpful anyway.