### PR TITLE
Fix "documentation" spelling

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -189,7 +189,7 @@
             <h2>WebGPU</h2>
             <p style="color:">WebGPU represents the next evolution in browser to GPU communication. The W3C&#x27;s GPU for the Web Community Group built it from the ground up with performance in mind. WebGPU offers web developers access to some of the most advanced modern graphics capabilities such as compute shaders and lightning-fast texture loading. We have been actively participating in the WebGPU Workgroup from its earliest days and are proud to announce that Babylon.js 5.0 offers FULL support for WebGPU.</p>
             <div class="link-block">
-                <a style="color:" href="https://doc.babylonjs.com/advanced_topics/webGPU/computeShader">WebGPU in Babylon.js documenation</a>
+                <a style="color:" href="https://doc.babylonjs.com/advanced_topics/webGPU/computeShader">WebGPU in Babylon.js documentation</a>
             </div>
         </div>
         <div>

--- a/src/content/config.json
+++ b/src/content/config.json
@@ -81,7 +81,7 @@
                 "title": "WebGPU",
                 "desc": "WebGPU represents the next evolution in browser to GPU communication. The W3C's GPU for the Web Community Group built it from the ground up with performance in mind. WebGPU offers web developers access to some of the most advanced modern graphics capabilities such as compute shaders and lightning-fast texture loading. We have been actively participating in the WebGPU Workgroup from its earliest days and are proud to announce that Babylon.js 5.0 offers FULL support for WebGPU.",
                 "moreInfoLink": "https://doc.babylonjs.com/advanced_topics/webGPU/computeShader",
-                "moreInfoText": "WebGPU in Babylon.js documenation"
+                "moreInfoText": "WebGPU in Babylon.js documentation"
             }
         },
         {


### PR DESCRIPTION
As seen on the homepage:

![image](https://user-images.githubusercontent.com/290626/175967026-db8c62ad-904e-4178-8b32-b60625085eec.png)
