### PR TITLE
Simple updates to site

### DIFF
--- a/src/content/community/config.json
+++ b/src/content/community/config.json
@@ -945,15 +945,6 @@
                         }
                     },
                     {
-                        "desc": "Marble Tower",
-                        "author": "by PirateJC",
-                        "link": "https://playground.babylonjs.com/#3I55DK#0",
-                        "img": {
-                            "url": "/community/assets/img/marbletower.jpg",
-                            "alt": "Marble Tower"
-                        }
-                    },
-                    {
                         "desc": "Local War",
                         "author": "by 蔬菜土豆泥",
                         "link": "http://localwar.xidayun.com/",

--- a/src/content/config.json
+++ b/src/content/config.json
@@ -340,7 +340,7 @@
         {
             "templateName": "imagesBlock",
             "content": {
-                "title": "FEATURED DEMOS",
+                "title": "NOTABLE DEMOS",
                 "desc": "Babylon.js is a fully-featured 3D framework built on the WebGL platform. The engine works seamlessly and transparently on both WebGL 1.0 and WebGL 2.0 platforms. And Babylon.js is available on the devices your users frequent:",
                 "items": [
                     {


### PR DESCRIPTION
Changed name for "Featured Demos" to "Notable Demos" to disambiguate with "Feature Demos" which are demos highlighting engine features. Also removed marble tower from community demos as it already exists in Feature Demos.