### PR TITLE
Remove reference to preview and point to the npm page

### DIFF
--- a/build/viewer/index.html
+++ b/build/viewer/index.html
@@ -320,12 +320,12 @@
   <section class="linkList-block" style="margin-top:;margin-bottom:30px">
     <div class="link-part">
         <div class="link" style="margin-left:;margin-right:">
-            <a href="https://github.com/BabylonJS/Babylon.js/blob/master/packages/public/%40babylonjs/viewer-alpha" class="link-part-link">
+            <a href="https://www.npmjs.com/package/@babylonjs/viewer" class="link-part-link">
                 <div class="icon-back">
                     <img class="backImage" src="/../assets/img/HexButtonStates.svg">
                     <img class="iconImage" src="/native/assets/img/NotesIcon.svg">
                 </div>
-                <div class="link-part-desc">Get the Preview</div>
+                <div class="link-part-desc">Get the Package</div>
             </a>
         </div>
         <div class="link" style="margin-left:;margin-right:">

--- a/src/content/viewer/config.json
+++ b/src/content/viewer/config.json
@@ -40,8 +40,8 @@
             "content": {
                 "items": [
                     {
-                        "desc": "Get the Preview",
-                        "link": "https://github.com/BabylonJS/Babylon.js/blob/master/packages/public/%40babylonjs/viewer-alpha",
+                        "desc": "Get the Package",
+                        "link": "https://www.npmjs.com/package/@babylonjs/viewer",
                         "img": {
                             "url": "/native/assets/img/NotesIcon.svg"
                         }


### PR DESCRIPTION
Don't call the Viewer a "preview" anymore, and point to the actual npm page (couldn't do this previously because you can't link to a package with a tag like `@preview`, only a **specific version** with the `-alpha` suffix).