### PR TITLE
Fix horizontal scroll and text wrapping on /lite page

### DIFF
--- a/src/assets/styles/ctaBlock.css
+++ b/src/assets/styles/ctaBlock.css
@@ -1,10 +1,5 @@
 .cta-block {
-    width: 100vw;
-    position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
+    width: 100%;
     background: linear-gradient(135deg, var(--midBackground), var(--darkBackground));
     padding: 60px 20px;
     text-align: center;

--- a/src/assets/styles/heroBlock.css
+++ b/src/assets/styles/heroBlock.css
@@ -1,10 +1,5 @@
 .hero-block {
     width: 100%;
-    position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
     padding: 70px 0 0;
     line-height: 0;
     overflow: hidden;

--- a/src/assets/styles/textBlock.css
+++ b/src/assets/styles/textBlock.css
@@ -1,10 +1,10 @@
 
 .content-container > .text-block {
-    width: 1200px;
+    width: 100%;
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 0;
     color: #E2E2E2;
-    padding: 0 !important;
+    padding: 0 15px !important;
 }
 
 .content-container > .text-block .inner-container {


### PR DESCRIPTION
## Problem

The `/lite` page showed a horizontal scrollbar, and the intro text block did not wrap to the viewport when the window was resized narrower than ~1200px (reported with a screenshot showing clipped/overflowing text and a bottom scrollbar).

## Root cause

Three CSS issues on blocks used by the `/lite` page:

1. **`textBlock.css`** — `.content-container > .text-block` used a fixed `width: 1200px` (plus `padding: 0 !important`). Below 1200px the text box stayed 1200px wide, so the paragraph wrapped at 1200px and overflowed the viewport. Between ~1025–1199px this produced a visible horizontal scrollbar; below 1024px it was only masked by a global `overflow-x: hidden`.
2. **`heroBlock.css`** — used the `width: 100vw; left: 50%; margin-left/right: -50vw` full-bleed hack. `100vw` includes the vertical scrollbar width, so it overflowed by ~half the scrollbar on every width (a thin persistent scrollbar with classic scrollbars). This completes the earlier partial fix in `5958b72c`, which set `width: 100%` but left the `-50vw` margins in place.
3. **`ctaBlock.css`** — same `100vw` / `-50vw` full-bleed hack as the hero block.

## Fix

- Text block: `width: 100%; max-width: 1200px` with `0 15px` gutters — fluid below 1200px, still centered at 1200px on desktop.
- Hero and CTA blocks: replaced the `100vw` / `-50vw` hack with plain `width: 100%`. Because `.content-container` is already full-bleed, both still span edge-to-edge.

## Verification

Built the site and measured document overflow with Playwright at 480–1400px:

- **No horizontal overflow at any width** (was 20–100px at 1100–1180px in headless).
- **Headed browser with classic 15px scrollbars:** `scrollWidth == clientWidth`, no horizontal scrollbar (was ~8px before the hero/CTA fix).
- Confirmed visually that the intro text wraps cleanly within the viewport with even gutters, and the hero image and CTA gradient still span full width.

Changes are limited to 3 CSS files; `heroBlock` and `ctaBlock` are only used on the `/lite` page.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>